### PR TITLE
FIX: PR Review feedback - path normalization and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,14 @@
 ._*
 
 # Application specific
-/config/settings.yaml  # Already included but good to keep
-*.inetloc             # Ignore local Mac URL files
-/projects/            # Ignore generated project folders if they're in the repo
-.env                  # For any environment variables (already commented)
+# Already included but good to keep
+/config/settings.yaml
+# Ignore local Mac URL files
+*.inetloc
+# Ignore generated project folders if they're in the repo
+/projects/
+# For any environment variables
+.env
 
 # IDE/Editor specific
 .vscode/
@@ -55,7 +59,8 @@
 
 # Dependencies
 /vendor/bundle/
-Gemfile.lock         # Consider tracking this for applications
+# Consider tracking this for applications
+Gemfile.lock
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:

--- a/models/project.rb
+++ b/models/project.rb
@@ -46,14 +46,13 @@ class Project
     end
 
     def generate_data_from_title(title)
-        data_hash = {}
         formatted_title             = self.generate_formatted_title(title)
         url_encoded_project_title   = self.generate_omnifocus_encoded_project_title(title)
         source_directory_path       = self._generate_source_directory_path(formatted_title)
         evernote_link               = ""
         omnifocus_link              = ""
         file_uri                    = "file://#{source_directory_path}"
-        data_hash =    {title: title, 
+        {title: title, 
                         formatted_title: formatted_title,
                         url_encoded_project_title: url_encoded_project_title,
                         source_directory_path: source_directory_path,
@@ -65,11 +64,11 @@ class Project
 
     def generate_formatted_title(title)
         date_string = Time.new.strftime("%Y-%m-%d")
-        project_title = "#{date_string}||#{title}"        
+        "#{date_string}||#{title}"        
     end
 
     def generate_omnifocus_encoded_project_title(title)
-        url_encoded_project_title = title.gsub(/\s/, '%20')              
+        title.gsub(/\s/, '%20')              
     end
 
     def _generate_source_directory_path(formatted_title)
@@ -78,15 +77,22 @@ class Project
         "#{project_base_path}#{clean_folder_name}"
     end
     def _generate_clean_folder_name(formatted_title)
-        project_base_path = _set_base_path
+        "#{_sanitize(formatted_title)}/"
     end
 
     def _sanitize(formatted_title)
-        clean_folder_name = formatted_title.gsub(/[^0-9A-Z]/i, '_')
+        formatted_title.gsub(/[^0-9A-Z]/i, '_')
     end
 
     def _set_base_path
-        ENV['PROJECTS_BASE_PATH'] || "#{ENV['HOME']}/Documents/projects/"
+        path = ENV['PROJECTS_BASE_PATH'].to_s.strip
+        if path.empty?
+            path = "#{ENV['HOME']}/Documents/projects/"
+        else
+            path = File.expand_path(path)
+        end
+        path += "/" unless path.end_with?("/")
+        path
     end
 
     def _obsidian_vault_path

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -65,6 +65,29 @@ RSpec.describe Project do
       result = project._set_base_path
       expect(result).to eq(custom_path)
     end
+
+    it 'adds a trailing slash if PROJECTS_BASE_PATH is missing one' do
+      custom_path = "/tmp/no_slash"
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('PROJECTS_BASE_PATH').and_return(custom_path)
+      result = project._set_base_path
+      expect(result).to eq("/tmp/no_slash/")
+    end
+
+    it 'falls back to default if PROJECTS_BASE_PATH is a blank string' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('PROJECTS_BASE_PATH').and_return("  ")
+      result = project._set_base_path
+      expect(result).to eq("#{ENV['HOME']}/Documents/projects/")
+    end
+
+    it 'expands paths (like ~) if present in PROJECTS_BASE_PATH' do
+      custom_path = "~/custom_projects"
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('PROJECTS_BASE_PATH').and_return(custom_path)
+      result = project._set_base_path
+      expect(result).to eq("#{ENV['HOME']}/custom_projects/")
+    end
   end
 
   describe '#_obsidian_vault_path' do


### PR DESCRIPTION
Addresses feedback from the Phase 1 PR:
- Normalizes `PROJECTS_BASE_PATH` (expansion and trailing slash)
- Fixes `.gitignore` patterns that included inline comments
- Cleans up unused variables in `Project` model